### PR TITLE
Add meta content for google to not try to translate the page

### DIFF
--- a/cmd/example-app/templates.go
+++ b/cmd/example-app/templates.go
@@ -38,6 +38,7 @@ type tokenTmplData struct {
 var tokenTmpl = template.Must(template.New("token.html").Parse(`<html>
   <head>
   <link rel="stylesheet" href="/static/stylesheet.css">
+  <meta name="google" content="notranslate">
   </head>
   <body>
     <div>


### PR DESCRIPTION
This stops the prompt from Chrome to translate the page. To test:

Create index.html and copy-paste the html template that was changed. Comment out the `notranslate` tag. Make sure you put in a k8s token for `{{ .IDToken }}` (replace some characters with x's) to trigger the prompt.

Start a server to visit index.html (`python -m SimpleHTTPServer` is fast). Observe translation prompt.

Uncomment the `notranslate` tag and refresh. No more prompt.